### PR TITLE
remove parens around TRACE

### DIFF
--- a/IRLib.cpp
+++ b/IRLib.cpp
@@ -1,4 +1,4 @@
-/* IRLib.cpp from IRLib – an Arduino library for infrared encoding and decoding
+/* IRLib.cpp from IRLib ï¿½ an Arduino library for infrared encoding and decoding
  * Version 1.31   January 2014
  * Copyright 2014 by Chris Young http://cyborg5.com
  *
@@ -86,7 +86,7 @@ void IRsendBase::sendGeneric(unsigned long data, unsigned char Num_Bits, unsigne
   }
   if(Use_Stop) mark(Mark_One);   //stop bit of "1"
   if(Max_Extent) {
-#ifdef (TRACE)
+#ifdef TRACE
     Serial.print("Max_Extent="); Serial.println(Max_Extent);
 	Serial.print("Extent="); Serial.println(Extent);
 	Serial.print("Difference="); Serial.println(Max_Extent-Extent);
@@ -449,7 +449,7 @@ bool IRdecodeSony::decode(void) {
  */
 
 /*
- * A very good source for protocol information is… http://www.hifi-remote.com/johnsfine/DecodeIR.html
+ * A very good source for protocol information isï¿½ http://www.hifi-remote.com/johnsfine/DecodeIR.html
  * I used that information to understand what they call the "Panasonic old" protocol which is used by
  * Scientific Atlanta cable boxes. That website uses a very strange notation called IRP notation.
  * For this protocol, the notation was:
@@ -669,8 +669,8 @@ bool IRdecodeHash::decode(void) {
 
 /* We have created a new receiver base class so that we can use its code to implement
  * additional receiver classes in addition to the original IRremote code which used
- * 50µs interrupt sampling of the input pin. See IRrecvLoop and IRrecvPCI classes
- * below. IRrecv is the original receiver class with the 50µs sampling.
+ * 50ï¿½s interrupt sampling of the input pin. See IRrecvLoop and IRrecvPCI classes
+ * below. IRrecv is the original receiver class with the 50ï¿½s sampling.
  */
 IRrecvBase::IRrecvBase(unsigned char recvpin)
 {
@@ -748,7 +748,7 @@ bool IRrecvLoop::GetResults(IRdecodeBase *decoder) {
 }
 
 /* This receiver uses the pin change hardware interrupt to detect when your input pin
- * changes state. It gives more detailed results than the 50µs interrupts of IRrecv
+ * changes state. It gives more detailed results than the 50ï¿½s interrupts of IRrecv
  * and theoretically is more accurate than IRrecvLoop. However because it only detects
  * pin changes, it doesn't always know when it's finished. GetResults attempts to detect
  * a long gap of space but sometimes the next signal gets there before GetResults notices.
@@ -894,7 +894,7 @@ void do_Blink(void) {
 }
 
 /*
- * The original IRrecv which uses 50µs timer driven interrupts to sample input pin.
+ * The original IRrecv which uses 50ï¿½s timer driven interrupts to sample input pin.
  */
 void IRrecv::resume() {
   // initialize state machine variables


### PR DESCRIPTION
parens cause compilation error under Arduino 1.0.5-r2
