### PR TITLE
Implemented settable beginning- and ending timeouts. Cleanup. 

### DIFF
--- a/IRLib.cpp
+++ b/IRLib.cpp
@@ -765,7 +765,7 @@ bool IRrecvLoop::GetResults(IRdecodeBase *decoder) {
 }
 #ifdef USE_ATTACH_INTERRUPTS
 /* This receiver uses the pin change hardware interrupt to detect when your input pin
- * changes state. It gives more detailed results than the 50µs interrupts of IRrecv
+ * changes state. It gives more detailed results than the 50us interrupts of IRrecv
  * and theoretically is more accurate than IRrecvLoop. However because it only detects
  * pin changes, it doesn't always know when it's finished. GetResults attempts to detect
  * a long gap of space but sometimes the next signal gets there before GetResults notices.
@@ -1002,7 +1002,7 @@ void do_Blink(void) {
 }
 #ifdef USE_IRRECV
 /*
- * The original IRrecv which uses 50µs timer driven interrupts to sample input pin.
+ * The original IRrecv which uses 50us timer driven interrupts to sample input pin.
  */
 void IRrecv::resume() {
   // initialize state machine variables

--- a/IRLib.cpp
+++ b/IRLib.cpp
@@ -666,8 +666,8 @@ bool IRdecodeRC6::decode(void) {
  * Converts the raw code values into a 32-bit hash code.
  * Hopefully this code is unique for each button.
  */
-#define FNV_PRIME_32 16777619
-#define FNV_BASIS_32 2166136261
+#define FNV_PRIME_32 16777619UL
+#define FNV_BASIS_32 2166136261UL
 // Compare two tick values, returning 0 if newval is shorter,
 // 1 if newval is equal, and 2 if newval is longer
 int IRdecodeHash::compare(unsigned int oldval, unsigned int newval) {
@@ -753,7 +753,7 @@ bool IRrecvLoop::GetResults(IRdecodeBase *decoder) {
   while(irparams.rawlen<RAWBUF) {  //While the buffer not overflowing
     while(OldState==(NewState=digitalRead(irparams.recvpin))) { //While the pin hasn't changed
       if( (DeltaTime = (EndTime=micros()) - StartTime) > 10000) { //If it's a very long wait
-        if(Finished=irparams.rawlen) break; //finished unless it's the opening gap
+        if((Finished=irparams.rawlen)) break; //finished unless it's the opening gap
       }
     }
     if(Finished) break;
@@ -798,6 +798,9 @@ void IRrecvPCI_Handler(){
       break;
     case STATE_IDLE:
        if(digitalRead(irparams.recvpin)) return; else irparams.rcvstate=STATE_RUNNING;
+       break;
+    default:
+       // do nothing
        break;
   };
   irparams.rawbuf[irparams.rawlen]=DeltaTime;
@@ -925,7 +928,7 @@ void IRfrequency::DumpResults(bool Detail) {
 
 //See IRLib.h comment explaining this function
  unsigned char Pin_from_Intr(unsigned char inum) {
-  const unsigned char PROGMEM attach_to_pin[]= {
+  const unsigned char attach_to_pin[]= {
 #if defined(__AVR_ATmega256RFR2__)//Assume Pinoccio Scout
 	4,5,SCL,SDA,RX1,TX1,7
 #elif defined(__AVR_ATmega32U4__) //Assume Arduino Leonardo
@@ -1118,6 +1121,9 @@ ISR(IR_RECV_INTR_NAME)
     if (irdata == IR_MARK) { // reset gap timer
       irparams.timer = 0;
     }
+    break;
+  default:
+    //nothing
     break;
   }
   do_Blink();

--- a/IRLib.h
+++ b/IRLib.h
@@ -1,4 +1,4 @@
-/* IRLib.h from IRLib – an Arduino library for infrared encoding and decoding
+/* IRLib.h from IRLib -- an Arduino library for infrared encoding and decoding
  * Version 1.51   March 2015
  * Copyright 2014 by Chris Young http://cyborg5.com
  *
@@ -276,10 +276,10 @@ protected:
   void Init(void);
 };
 
-/* Original IRrecv class uses 50µs interrupts to sample input. While this is generally
+/* Original IRrecv class uses 50us interrupts to sample input. While this is generally
  * accurate enough for everyday purposes, it may be difficult to port to other
  * hardware unless you know a lot about hardware timers and interrupts. Also
- * when trying to analyze unknown protocols, the 50µs granularity may not be sufficient.
+ * when trying to analyze unknown protocols, the 50us granularity may not be sufficient.
  * In that case use either the IRrecvLoop or the IRrecvPCI class.
  */
 #ifdef USE_IRRECV
@@ -309,7 +309,7 @@ public:
 };
 
 /* This receiver uses the pin change hardware interrupt to detect when your input pin
- * changes state. It gives more detailed results than the 50µs interrupts of IRrecv
+ * changes state. It gives more detailed results than the 50us interrupts of IRrecv
  * and theoretically is more accurate than IRrecvLoop. However because it only detects
  * pin changes, it doesn't always know when it's finished. GetResults attempts to detect
  * a long gap of space but sometimes the next signal gets there before GetResults notices.
@@ -365,10 +365,10 @@ private:
 void do_Blink(void);
 
 /* This routine maps interrupt numbers used by attachInterrupt() into pin numbers.
- * NOTE: these interrupt numbers which are passed to “attachInterrupt()” are not 
+ * NOTE: these interrupt numbers which are passed to "attachInterrupt()" are not 
  * necessarily identical to the interrupt numbers in the datasheet of the processor 
  * chip you are using. These interrupt numbers are a system unique to the 
- * “attachInterrupt()” Arduino function.  It is used by both IRrecvPCI and IRfrequency.
+ * "attachInterrupt()" Arduino function.  It is used by both IRrecvPCI and IRfrequency.
  */
 unsigned char Pin_from_Intr(unsigned char inum);
 // Some useful constants

--- a/IRLib.h
+++ b/IRLib.h
@@ -66,7 +66,7 @@
 
 #define _GAP 5000 // Default timeout value in microseconds
 
-typedef char IRTYPES; //formerly was an enum
+typedef unsigned char IRTYPES; //formerly was an enum
 #define UNKNOWN 0
 #define NEC 1
 #define SONY 2
@@ -268,6 +268,7 @@ class IRrecvBase
 public:
   IRrecvBase(void) {};
   IRrecvBase(unsigned char recvpin);
+  virtual ~IRrecvBase() {};
   void No_Output(void);
   void blink13(bool blinkflag);
   bool GetResults(IRdecodeBase *decoder, const unsigned int Time_per_Ticks=1);

--- a/IRLib.h
+++ b/IRLib.h
@@ -64,6 +64,8 @@
 
 #define RAWBUF 100 // Length of raw duration buffer (cannot exceed 255)
 
+#define _GAP 5000 // Default timeout value in microseconds
+
 typedef char IRTYPES; //formerly was an enum
 #define UNKNOWN 0
 #define NEC 1
@@ -188,6 +190,7 @@ public:
   void sendGeneric(unsigned long data,  unsigned char Num_Bits, unsigned int Head_Mark, unsigned int Head_Space, 
                    unsigned int Mark_One, unsigned int Mark_Zero, unsigned int Space_One, unsigned int Space_Zero, 
 				   unsigned char kHz, bool Stop_Bits, unsigned long Max_Extent=0);
+  static void No_Output(void);
 protected:
   void enableIROut(unsigned char khz);
   VIRTUAL void mark(unsigned int usec);
@@ -289,7 +292,11 @@ public:
   IRrecv(unsigned char recvpin):IRrecvBase(recvpin){};
   bool GetResults(IRdecodeBase *decoder);
   void enableIRIn(void);
+  void disableIRIn(void);
   void resume(void);
+  static void setEndingTimeout(unsigned long timeOut);
+  static unsigned long getEndingTimeout(void);
+  unsigned static long GAP_TICKS; //must be public & static for the ISR
 };
 #endif
 /* This receiver uses no interrupts or timers. Other interrupt driven receivers

--- a/IRLib.h
+++ b/IRLib.h
@@ -296,7 +296,10 @@ public:
   void resume(void);
   static void setEndingTimeout(unsigned long timeOut);
   static unsigned long getEndingTimeout(void);
+  static void setBeginningTimeout(unsigned long timeOut);
+  static unsigned long getBeginningTimeout(void);
   unsigned static long GAP_TICKS; //must be public & static for the ISR
+  unsigned static long TIMEOUT_TICKS; //must be public & static for the ISR
 };
 #endif
 /* This receiver uses no interrupts or timers. Other interrupt driven receivers

--- a/IRLibMatch.h
+++ b/IRLibMatch.h
@@ -1,4 +1,4 @@
-/* IRLibMatch.h from IRLib – an Arduino library for infrared encoding and decoding
+/* IRLibMatch.h from IRLib -- an Arduino library for infrared encoding and decoding
  * Version 1.5   June 2014
  * Copyright 2014 by Chris Young http://cyborg5.com
  *

--- a/IRLibRData.h
+++ b/IRLibRData.h
@@ -1,4 +1,4 @@
-/* IRLibRData.h from IRLib – an Arduino library for infrared encoding and decoding
+/* IRLibRData.h from IRLib -- an Arduino library for infrared encoding and decoding
  * Version 1.5   June 2014
  * Copyright 2014 by Chris Young http://cyborg5.com
  *

--- a/IRLibTimer.h
+++ b/IRLibTimer.h
@@ -1,4 +1,4 @@
-/* IRLibTimer.h from IRLib – an Arduino library for infrared encoding and decoding
+/* IRLibTimer.h from IRLib -- an Arduino library for infrared encoding and decoding
  * Version 1.5   June 2014
  * Copyright 2014 by Chris Young http://cyborg5.com
  *


### PR DESCRIPTION
These changes implements settable beginning- and ending timeout. The begin timeout is the time it takes for the receive to time out if no IR activity has been detected. The ending timeout is the amount of silence after the signal required to consider the IR signal as finished. Set this short (e.g. 30 ms) to separate different protocols, set it larger (e.g. 100ms)  to lump e.g. a NEC1 signal with its repeats.

I removed some Windows-1252 characters, since the Arduino IDE was complaining. I also fixed the -Wall complier warnings, except for one.  
